### PR TITLE
fix(system): support multiple cycle detections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 vendor/
+*.out
+.coverprofile

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ go:
   - 1.11
 
 before_install:
+  - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
+  - go get github.com/modocache/gover
 
 script:
-  - go test -v -bench=. ./...
-  - $GOPATH/bin/goveralls -service=travis-ci
+  - go list -f '{{if len .TestGoFiles}}"go test -v -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' ./... | xargs -L 1 sh -c
+  - gover
+  - goveralls -coverprofile=gover.coverprofile -service=travis-ci

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,9 @@ The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog],
 and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Versioning].
 
 == [Unreleased]
+=== Fixed
+
+* Allow detection of deep and multiple cycles in a node system.
 
 == [0.3.0] - 2018-10-11
 === Added

--- a/system/github_issues_test.go
+++ b/system/github_issues_test.go
@@ -2,7 +2,10 @@ package system
 
 import (
 	"errors"
+	"fmt"
 	"testing"
+
+	"github.com/rlespinasse/hoff/internal/nodelink"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/rlespinasse/hoff/internal/utils"
@@ -38,6 +41,113 @@ func Test_Github_Issue_10(t *testing.T) {
 
 	expectedErrors := []error{
 		errors.New("can't have multiple links (2) to the same node: action4 without join mode"),
+	}
+
+	if !cmp.Equal(errs, expectedErrors, utils.ErrorComparator) {
+		t.Errorf("errors - got: %+v, want: %+v", errs, expectedErrors)
+	}
+}
+
+func Test_Github_Issue_16(t *testing.T) {
+	trigger, _ := node.NewDecision("trigger", func(c *node.Context) (bool, error) {
+		return true, nil
+	})
+	a1, _ := node.NewAction("a1", func(c *node.Context) error {
+		return nil
+	})
+	a2, _ := node.NewAction("a2", func(c *node.Context) error {
+		return nil
+	})
+	a3, _ := node.NewAction("a3", func(c *node.Context) error {
+		return nil
+	})
+
+	ns := New()
+	ns.AddNode(trigger)
+	ns.AddNode(a1)
+	ns.AddNode(a2)
+	ns.AddNode(a3)
+	ns.AddLinkOnBranch(trigger, a1, true)
+	ns.AddLink(a1, a2)
+	ns.AddLink(a2, a3)
+	ns.AddLink(a3, a2)
+	ns.ConfigureJoinModeOnNode(a2, joinmode.AND)
+	_, errs := ns.IsValid()
+
+	expectedErrors := []error{
+		fmt.Errorf("Can't have cycle in links between nodes: %+v", []nodelink.NodeLink{
+			nodelink.New(a2, a3),
+			nodelink.New(a3, a2),
+		}),
+	}
+
+	if !cmp.Equal(errs, expectedErrors, utils.ErrorComparator) {
+		t.Errorf("errors - got: %+v, want: %+v", errs, expectedErrors)
+	}
+}
+
+func Test_multiple_cycles(t *testing.T) {
+	trigger, _ := node.NewDecision("trigger", func(c *node.Context) (bool, error) {
+		return true, nil
+	})
+	a1, _ := node.NewAction("a1", func(c *node.Context) error {
+		return nil
+	})
+	a2, _ := node.NewAction("a2", func(c *node.Context) error {
+		return nil
+	})
+	a3, _ := node.NewAction("a3", func(c *node.Context) error {
+		return nil
+	})
+	a4, _ := node.NewAction("a4", func(c *node.Context) error {
+		return nil
+	})
+	a5, _ := node.NewAction("a5", func(c *node.Context) error {
+		return nil
+	})
+	a6, _ := node.NewAction("a6", func(c *node.Context) error {
+		return nil
+	})
+	a7, _ := node.NewAction("a7", func(c *node.Context) error {
+		return nil
+	})
+
+	ns := New()
+	ns.AddNode(trigger)
+	ns.AddNode(a1)
+	ns.AddNode(a2)
+	ns.AddNode(a3)
+	ns.AddNode(a4)
+	ns.AddNode(a5)
+	ns.AddNode(a6)
+	ns.AddNode(a7)
+
+	// Cycle between a2 and a3
+	ns.AddLinkOnBranch(trigger, a1, true)
+	ns.AddLink(a1, a2)
+	ns.AddLink(a2, a3)
+	ns.AddLink(a3, a2)
+	ns.ConfigureJoinModeOnNode(a2, joinmode.AND)
+
+	// Cycle between a5, a6, and a7
+	ns.AddLinkOnBranch(trigger, a4, false)
+	ns.AddLink(a4, a5)
+	ns.AddLink(a5, a6)
+	ns.AddLink(a6, a7)
+	ns.AddLink(a7, a5)
+	ns.ConfigureJoinModeOnNode(a5, joinmode.AND)
+	_, errs := ns.IsValid()
+
+	expectedErrors := []error{
+		fmt.Errorf("Can't have cycle in links between nodes: %+v", []nodelink.NodeLink{
+			nodelink.New(a2, a3),
+			nodelink.New(a3, a2),
+		}),
+		fmt.Errorf("Can't have cycle in links between nodes: %+v", []nodelink.NodeLink{
+			nodelink.New(a5, a6),
+			nodelink.New(a6, a7),
+			nodelink.New(a7, a5),
+		}),
 	}
 
 	if !cmp.Equal(errs, expectedErrors, utils.ErrorComparator) {

--- a/system/nodesystem_test.go
+++ b/system/nodesystem_test.go
@@ -332,7 +332,7 @@ func Test_NodeSystem_IsValid(t *testing.T) {
 			},
 		},
 		{
-			name: "Can't have cycle between some links",
+			name: "Can't have cycle between 2 links",
 			givenNodes: []node.Node{
 				someActionNode,
 				anotherActionNode,
@@ -353,7 +353,44 @@ func Test_NodeSystem_IsValid(t *testing.T) {
 				},
 			},
 			expectedErrors: []error{
-				fmt.Errorf("Can't have cycle between links: %+v", []nodelink.NodeLink{
+				fmt.Errorf("Can't have cycle in links between nodes: %+v", []nodelink.NodeLink{
+					nodelink.New(someActionNode, anotherActionNode),
+					nodelink.New(anotherActionNode, someActionNode),
+				}),
+			},
+		},
+		{
+			name: "Can't have cycle between some links",
+			givenNodes: []node.Node{
+				alwaysTrueDecisionNode,
+				someActionNode,
+				anotherActionNode,
+			},
+			givenLinks: []nodelink.NodeLink{
+				nodelink.NewOnBranch(alwaysTrueDecisionNode, someActionNode, true),
+				nodelink.New(someActionNode, anotherActionNode),
+				nodelink.New(anotherActionNode, someActionNode),
+			},
+			givenNodesJoinModes: map[node.Node]joinmode.JoinMode{
+				someActionNode: joinmode.AND,
+			},
+			expectedNodeSystem: &NodeSystem{
+				nodes: []node.Node{
+					alwaysTrueDecisionNode,
+					someActionNode,
+					anotherActionNode,
+				},
+				nodesJoinModes: map[node.Node]joinmode.JoinMode{
+					someActionNode: joinmode.AND,
+				},
+				links: []nodelink.NodeLink{
+					nodelink.NewOnBranch(alwaysTrueDecisionNode, someActionNode, true),
+					nodelink.New(someActionNode, anotherActionNode),
+					nodelink.New(anotherActionNode, someActionNode),
+				},
+			},
+			expectedErrors: []error{
+				fmt.Errorf("Can't have cycle in links between nodes: %+v", []nodelink.NodeLink{
 					nodelink.New(someActionNode, anotherActionNode),
 					nodelink.New(anotherActionNode, someActionNode),
 				}),
@@ -385,7 +422,7 @@ func Test_NodeSystem_IsValid(t *testing.T) {
 				},
 			},
 			expectedErrors: []error{
-				fmt.Errorf("Can't have cycle between links: %+v", []nodelink.NodeLink{
+				fmt.Errorf("Can't have cycle in links between nodes: %+v", []nodelink.NodeLink{
 					nodelink.NewOnBranch(alwaysTrueDecisionNode, anotherActionNode, false),
 					nodelink.New(anotherActionNode, alwaysTrueDecisionNode),
 				}),


### PR DESCRIPTION
A cycle can be detected without been the first node of the node system

Multiple cycles can be found in the same node system

Closes #16 